### PR TITLE
feat: handle Gateway disconnections

### DIFF
--- a/one_shard.py
+++ b/one_shard.py
@@ -1,0 +1,6 @@
+import pycord
+
+# a discord bot connecting to the gateway with 1 shard and an intent number of 0
+bot = pycord.Bot(0, level='DEBUG')
+
+bot.run('OTI0MTgzMjExOTIyMzEzMjE2.GF86XC.voTgkm3L1UxdIBGdLkp2Rwn8trUp3GpBtbNMvQ')

--- a/one_shard.py
+++ b/one_shard.py
@@ -1,6 +1,0 @@
-import pycord
-
-# a discord bot connecting to the gateway with 1 shard and an intent number of 0
-bot = pycord.Bot(0, level='DEBUG')
-
-bot.run('OTI0MTgzMjExOTIyMzEzMjE2.GF86XC.voTgkm3L1UxdIBGdLkp2Rwn8trUp3GpBtbNMvQ')

--- a/pycord/bot.py
+++ b/pycord/bot.py
@@ -38,5 +38,9 @@ class Bot(RESTApp):
         self._state.gateway_enabled = True
 
         self.shard_manager = ShardManager(self.shards, self._state, self.dispatcher, self._version)
-        # .run already sets token to a non-None type.
+        # .run/.start already sets token to a non-None type.
         await self.shard_manager.connect(self.token)  # type: ignore
+
+    async def close(self):
+        await super().close()
+        await self.shard_manager.disconnect()

--- a/pycord/internal/gateway/manager.py
+++ b/pycord/internal/gateway/manager.py
@@ -32,9 +32,7 @@ class ShardManager:
         self.state = state
         self.version = version
         self.events = events
-        self.running = False
         self.token = ""
-        self._loop_task: asyncio.Task | None = None
 
     async def connect(self, token: str) -> None:
         self.token = token
@@ -45,27 +43,20 @@ class ShardManager:
             self.shards.append(shard)
             await asyncio.sleep(5)
 
-        self.running = True
-        self._loop_task = asyncio.create_task(self.loop())
-
-    async def loop(self) -> None:
-        while True:
-            try:
-                for i, shard in enumerate(self.shards):
-                    if shard._ws.closed and shard._reconnectable:
-                        # the websocket is closed, we have to reconnect
-                        await shard.connect(token=self.token)
-                    elif not shard._reconnectable:
-                        # we cannot reconnect, so we have to recreate the shard
-                        new_shard = Shard(i, self._shards, self.state, self.events, self.version)
-                        await new_shard.connect(token=self.token)
-                        self.shards[i] = new_shard
-            except asyncio.CancelledError:
-                break
-
     async def disconnect(self) -> None:
-        self._loop_task.cancel()
-        await self._loop_task
-
         for shard in self.shards:
             await shard.disconnect(reconnect=False)
+
+    async def _shard_disconnected_hook(self, shard: Shard, shard_id: int):
+        if shard._ws.closed and shard._reconnectable:
+            # the websocket is closed, we have to reconnect
+            await shard.connect(token=self.token)
+        elif not shard._reconnectable:
+            # we cannot reconnect, so we have to recreate the shard
+            new_shard = Shard(shard_id, self._shards, self.state, self.events, self.version)
+            await new_shard.connect(token=self.token)
+            self.shards[shard_id] = new_shard
+
+    def shard_disconnected_hook(self, shard_id: int):
+        shard = self.shards[shard_id]
+        return asyncio.create_task(self._shard_disconnected_hook(shard, shard_id))

--- a/pycord/internal/gateway/manager.py
+++ b/pycord/internal/gateway/manager.py
@@ -32,10 +32,40 @@ class ShardManager:
         self.state = state
         self.version = version
         self.events = events
+        self.running = False
+        self.token = ""
+        self._loop_task: asyncio.Task | None = None
 
     async def connect(self, token: str) -> None:
+        self.token = token
+
         for i in range(self._shards):
             shard = Shard(i, self._shards, self.state, self.events, self.version)
-            await shard.connect(token=token)
+            await shard.connect(token=self.token)
             self.shards.append(shard)
             await asyncio.sleep(5)
+
+        self.running = True
+        self._loop_task = asyncio.create_task(self.loop())
+
+    async def loop(self) -> None:
+        while True:
+            try:
+                for i, shard in enumerate(self.shards):
+                    if shard._ws.closed and shard._reconnectable:
+                        # the websocket is closed, we have to reconnect
+                        await shard.connect(token=self.token)
+                    elif not shard._reconnectable:
+                        # we cannot reconnect, so we have to recreate the shard
+                        new_shard = Shard(i, self._shards, self.state, self.events, self.version)
+                        await new_shard.connect(token=self.token)
+                        self.shards[i] = new_shard
+            except asyncio.CancelledError:
+                break
+
+    async def disconnect(self) -> None:
+        self._loop_task.cancel()
+        await self._loop_task
+
+        for shard in self.shards:
+            await shard.disconnect(reconnect=False)

--- a/pycord/internal/gateway/shard.py
+++ b/pycord/internal/gateway/shard.py
@@ -27,7 +27,7 @@ import zlib
 from typing import Any
 
 from aiohttp import WSMsgType
-from discord_typings.gateway import GatewayEvent#HelloEvent, InvalidSessionEvent
+from discord_typings.gateway import GatewayEvent
 
 from pycord import utils
 


### PR DESCRIPTION
This PR adds support for shards/the shard manager to handle disconnections. To do this, the shard manager has a loop that is started in the connect function that actively monitors every shard. If a shard has disconnected and is able to reconnect, then the shard's connect function is called. Otherwise, the shard is recreated.